### PR TITLE
🐛 Fix schema create error

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -179,7 +179,7 @@ async function storeTaskDetailsUpdate(taskID, details) {
  * createTables
  */
 async function createTables() {
-  await pool.query('CREATE SCHEMA stampede;')
+  await pool.query('CREATE SCHEMA IF NOT EXISTS stampede;')
 
   await pool.query('CREATE TABLE IF NOT EXISTS stampede.repositories \
     (owner varchar, \


### PR DESCRIPTION
Fixes a bug when re-launching portal it was trying to create the schema again.

Now it will only create the schema if it doesn't already exist.