### PR TITLE
🐛 Make public path based on directory of the main js file

### DIFF
--- a/lib/web.js
+++ b/lib/web.js
@@ -14,7 +14,7 @@ const bodyParser = require('body-parser')
 app.use(morgan('dev'))
 app.use(bodyParser.json({limit: '50mb'}))
 app.use(bodyParser.urlencoded({extended: true}))
-app.use(express.static('public'))
+app.use(express.static(__dirname + '/../public'))
 app.set('view engine', 'pug')
 
 /**


### PR DESCRIPTION
This PR fixes an issue where the server can't find the public files. This can happen when you installed the portal globally rather than just running it from the root folder directly.