### PR TITLE
✨ activeBuilds API now accepts owner and repo params

### DIFF
--- a/api/activeBuilds.js
+++ b/api/activeBuilds.js
@@ -15,7 +15,7 @@ async function handle(req, res, serverConf, cache, db) {
   if (req.query.owner != null) {
     prefix = req.query.owner + '-' + prefix
   }
-  const filteredBuilds = activeBuilds.filter(build => build.startsWith(prefix))
+  const filteredBuilds = activeBuilds.filter((build) => build.startsWith(prefix))
   const builds = []
   for (let index = 0; index < filteredBuilds.length; index++) {
     const buildID = filteredBuilds[index]


### PR DESCRIPTION
This PR updates the activeBuilds api to allow for passing in an owner and repository. These are used to filter the list. Or you can leave them off, or just pass in owner.