### PR TITLE
✨ Cancel task now available

### DIFF
--- a/controllers/monitor/cancelTask.js
+++ b/controllers/monitor/cancelTask.js
@@ -1,0 +1,35 @@
+const Queue = require("bull");
+
+/**
+ * handle requeueTask
+ * @param {*} req
+ * @param {*} res
+ * @param {*} cache
+ * @param {*} db
+ * @param {*} path
+ */
+async function handle(req, res, cache, db, path, redisConfig) {
+  const taskRows = await db.fetchTask(req.query.taskID);
+  const task = taskRows.rows[0];
+  const detailsRows = await db.fetchTaskDetails(req.query.taskID);
+  const taskDetails = detailsRows.rows[0].details;
+  const buildRows = await db.fetchBuild(task.build_id);
+  const build = buildRows.rows[0];
+
+  taskDetails.stats.finished_at = new Date();
+  taskDetails.status = "completed";
+  taskDetails.result = {
+    conclusion: "cancelled"
+  };
+
+  const taskQueue = new Queue("stampede-response", redisConfig);
+  taskQueue.add(taskDetails, { removeOnComplete: true, removeOnFail: true });
+  taskQueue.close();
+  res.render(path + "monitor/cancelTask", {
+    task: task,
+    taskDetails: taskDetails,
+    build: build
+  });
+}
+
+module.exports.handle = handle;

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -22,6 +22,7 @@ const monitorBuildDetails = require("../controllers/monitor/buildDetails");
 const monitorBuildTaskDetails = require("../controllers/monitor/buildTaskDetails");
 const monitorQueues = require("../controllers/monitor/queues");
 const monitorRequeueTask = require("../controllers/monitor/requeueTask");
+const monitorCancelTask = require("../controllers/monitor/cancelTask");
 
 // History
 const historyBuilds = require("../controllers/history/builds");
@@ -126,6 +127,10 @@ function router(cache, db, path, conf) {
 
   basicRouter.get("/monitor/requeueTask", function(req, res) {
     monitorRequeueTask.handle(req, res, cache, db, path, redisConfig);
+  });
+
+  basicRouter.get("/monitor/cancelTask", function(req, res) {
+    monitorCancelTask.handle(req, res, cache, db, path, redisConfig);
   });
 
   // History

--- a/views/monitor/buildDetails.pug
+++ b/views/monitor/buildDetails.pug
@@ -35,7 +35,6 @@ block content
               +tableRow()
                 +tableCell('Started At')
                 +tableCell(build.started_at)
-              
 
   div(class="w-full p-3")
       div(class="bg-white border-transparent rounded-lg shadow-lg")

--- a/views/monitor/buildTaskDetails.pug
+++ b/views/monitor/buildTaskDetails.pug
@@ -26,9 +26,11 @@ block content
                 +tableCell('Node')
                 +tableCell(task.node)
               +tableRow()
-                  +tableCellButton('Requeue', '/monitor/requeueTask?taskID=' + task.task_id)
+                +tableCellButton('Requeue', '/monitor/requeueTask?taskID=' + task.task_id)
+                if task.conclusion == null
+                  +tableCellButton('Cancel', '/monitor/cancelTask?taskID=' + task.task_id)
+                else
                   +tableCell('')
-
 
     +infoCard('Task Config')
         table(class="table-auto w-full")

--- a/views/monitor/cancelTask.pug
+++ b/views/monitor/cancelTask.pug
@@ -1,0 +1,15 @@
+extends ../layout
+include ../components/titleBar
+include ../components/tableHeader
+include ../components/tableCell
+include ../components/tableRow
+
+block content
+
+  +titleBar([{title: 'Active Builds', href: '/monitor/activeBuilds'},
+  {title: build.owner + '' + build.repository + ' #' + build.build, href: '/monitor/buildDetails?buildID=' + build.build_id},
+  {title: task.task_id}
+  ])
+  div(class="flex flex-wrap m-4")
+
+  h5 Task Cancelled


### PR DESCRIPTION
This PR adds a cancel button to any in progress/queued tasks. This can be found in the monitor flow for the active build. Instead of cancelling a build, cancel task seemed more in line with the current codebase, so it was implemented instead.

Still marking this as closed #33 