### PR TITLE
✨ Now supports config source display

### DIFF
--- a/controllers/history/buildTaskDetails.js
+++ b/controllers/history/buildTaskDetails.js
@@ -15,11 +15,15 @@ async function handle(req, res, cache, db, path) {
   Object.keys(
     taskDetails.details.config != null ? taskDetails.details.config : {}
   ).forEach(function(key) {
-    configValues.push({ key: key, value: taskDetails.details.config[key] });
+    configValues.push({
+      key: key,
+      value: taskDetails.details.config[key].value,
+      source: taskDetails.details.config[key].source
+    });
   });
   const buildRows = await db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
-  res.render(path + 'history/buildTaskDetails', {
+  res.render(path + "history/buildTaskDetails", {
     task: task,
     build: build,
     taskDetails: taskDetails,

--- a/controllers/history/taskDetails.js
+++ b/controllers/history/taskDetails.js
@@ -15,11 +15,15 @@ async function handle(req, res, cache, db, path) {
   Object.keys(
     taskDetails.details.config != null ? taskDetails.details.config : {}
   ).forEach(function(key) {
-    configValues.push({ key: key, value: taskDetails.details.config[key] });
+    configValues.push({
+      key: key,
+      value: taskDetails.details.config[key].value,
+      source: taskDetails.details.config[key].source
+    });
   });
   const buildRows = await db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
-  res.render(path + 'history/taskDetails', {
+  res.render(path + "history/taskDetails", {
     task: task,
     build: build,
     taskDetails: taskDetails,

--- a/controllers/monitor/buildTaskDetails.js
+++ b/controllers/monitor/buildTaskDetails.js
@@ -15,11 +15,15 @@ async function handle(req, res, cache, db, path) {
   Object.keys(
     taskDetails.details.config != null ? taskDetails.details.config : {}
   ).forEach(function(key) {
-    configValues.push({ key: key, value: taskDetails.details.config[key] });
+    configValues.push({
+      key: key,
+      value: taskDetails.details.config[key].value,
+      source: taskDetails.details.config[key].source
+    });
   });
   const buildRows = await db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
-  res.render(path + 'monitor/buildTaskDetails', {
+  res.render(path + "monitor/buildTaskDetails", {
     task: task,
     build: build,
     taskDetails: taskDetails,

--- a/controllers/repositories/taskDetails.js
+++ b/controllers/repositories/taskDetails.js
@@ -15,11 +15,15 @@ async function handle(req, res, cache, db, path) {
   Object.keys(
     taskDetails.details.config != null ? taskDetails.details.config : {}
   ).forEach(function(key) {
-    configValues.push({ key: key, value: taskDetails.details.config[key] });
+    configValues.push({
+      key: key,
+      value: taskDetails.details.config[key].value,
+      source: taskDetails.details.config[key].source
+    });
   });
   const buildRows = await db.fetchBuild(task.build_id);
   const build = buildRows.rows[0];
-  res.render(path + 'repositories/taskDetails', {
+  res.render(path + "repositories/taskDetails", {
     task: task,
     build: build,
     taskDetails: taskDetails,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "bin/stampede-portal.js",
   "scripts": {
     "start": "bin/stampede-portal.js",
+    "dev": "nodemon bin/stampede-portal.js",
     "test": "mocha",
     "lint": "eslint $(find . -name \"*.js\" -not -path \"./node_modules/*\" -not -path \"./public/*\")",
     "lint-fix": "eslint --fix $(find . -name \"*.js\" -not -path \"./node_modules/*\" -not -path \"./public/*\")",

--- a/views/history/buildTaskDetails.pug
+++ b/views/history/buildTaskDetails.pug
@@ -34,11 +34,13 @@ block content
         table(class="table-auto w-full")
             thead
               +tableHeader('Config Parameter')
+              +tableHeader('Source')
               +tableHeader('Value')
             tbody
                 each config, i in configValues
                     +tableRow()
                         +tableCell(config.key)
+                        +tableCell(config.source)
                         +tableCell(config.value)
 
 

--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -27,11 +27,13 @@ block content
         table(class="table-auto w-full")
             thead
               +tableHeader('Config Parameter')
+              +tableHeader('Source')
               +tableHeader('Value')
             tbody
                 each config, i in configValues
                     +tableRow()
                         +tableCell(config.key)
+                        +tableCell(config.source)
                         +tableCell(config.value)
 
 

--- a/views/monitor/buildTaskDetails.pug
+++ b/views/monitor/buildTaskDetails.pug
@@ -36,11 +36,13 @@ block content
         table(class="table-auto w-full")
             thead
               +tableHeader('Config Parameter')
+              +tableHeader('Source')
               +tableHeader('Value')
             tbody
                 each config, i in configValues
                     +tableRow()
                         +tableCell(config.key)
+                        +tableCell(config.source)
                         +tableCell(config.value)
 
 

--- a/views/repositories/taskDetails.pug
+++ b/views/repositories/taskDetails.pug
@@ -34,11 +34,13 @@ block content
         table(class="table-auto w-full")
             thead
               +tableHeader('Config Parameter')
+              +tableHeader('Source')
               +tableHeader('Value')
             tbody
                 each config, i in configValues
                     +tableRow()
                         +tableCell(config.key)
+                        +tableCell(config.source)
                         +tableCell(config.value)
 
 


### PR DESCRIPTION
This PR updates the task details screens to add the config `source` so you can tell where the value was derived from.

Closes #108 