### PR TITLE
🐛 Process notifications in order

### DIFF
--- a/lib/notifications.js
+++ b/lib/notifications.js
@@ -29,7 +29,7 @@ async function start(conf, db) {
         chalk.yellow(job.data.id) +
         "]"
     );
-    processJob(job, db);
+    return processJob(job, db);
   });
 }
 


### PR DESCRIPTION
This PR fixes an issue with how the portal handles notifications from the server. It needs to handle them in-order since for tasks we usually get 3 messages at least: started, updated & completed. If they aren't processed in order, the db doesn't get updated correctly.

Closes #138 