### PR TITLE
✨ Added task start and finish to task history details

### DIFF
--- a/views/history/taskDetails.pug
+++ b/views/history/taskDetails.pug
@@ -22,6 +22,12 @@ block content
               +tableRow()
                 +tableCell('Node')
                 +tableCell(task.node)
+              +tableRow()
+                +tableCell('Started')
+                +tableCell(task.started_at)
+              +tableRow()
+                +tableCell('Finished')
+                +tableCell(task.finished_at)
 
     +infoCard('Build Information')
         table(class="table-auto w-full")


### PR DESCRIPTION
This PR adds some start and finish times to the task history details screen.

Closes #142 