### PR TITLE
🐛 Fixed problem in cancel task

### DIFF
--- a/controllers/monitor/cancelTask.js
+++ b/controllers/monitor/cancelTask.js
@@ -23,7 +23,10 @@ async function handle(req, res, cache, db, path, redisConfig) {
   };
 
   const taskQueue = new Queue("stampede-response", redisConfig);
-  taskQueue.add(taskDetails, { removeOnComplete: true, removeOnFail: true });
+  taskQueue.add(
+    { response: "taskUpdate", payload: taskDetails },
+    { removeOnComplete: true, removeOnFail: true }
+  );
   taskQueue.close();
   res.render(path + "monitor/cancelTask", {
     task: task,


### PR DESCRIPTION
This PR fixes a problem in the cancel task feature from the Portal. Due to how the response queue was changed, the cancel messages were getting ignored by the server.

Closes #159 