### PR TITLE
✨ Do not show graph and stats if no task executions in filter

### DIFF
--- a/views/history/taskSummary.pug
+++ b/views/history/taskSummary.pug
@@ -26,48 +26,51 @@ block content
     each graph, i in graphs
 
       +infoCard(graph.task)
-        div(class="chart-container w-full")
-          canvas(id=``+graph.task height="100")
-            script.
-              var chartData = JSON.parse('!{JSON.stringify(graph.data)}');
-              var ctx = document.getElementById('!{graph.task}').getContext('2d');
-              var myChart = new Chart(ctx, {
-              type: 'bar',
-              data: chartData,
-              options: {
-                responsive: true,
-                  scales: {
-                      xAxes: [{
-                        ticks: {
-                          display: false //this will remove only the label
-                        }
-                      }],
-                      yAxes: [{
+        if graph.summary.total > 0
+          div(class="chart-container w-full")
+            canvas(id=``+graph.task height="100")
+              script.
+                var chartData = JSON.parse('!{JSON.stringify(graph.data)}');
+                var ctx = document.getElementById('!{graph.task}').getContext('2d');
+                var myChart = new Chart(ctx, {
+                type: 'bar',
+                data: chartData,
+                options: {
+                  responsive: true,
+                    scales: {
+                        xAxes: [{
                           ticks: {
-                              beginAtZero: true,
+                            display: false //this will remove only the label
                           }
-                      }]
-                  }
-              }
-              });
+                        }],
+                        yAxes: [{
+                            ticks: {
+                                beginAtZero: true,
+                            }
+                        }]
+                    }
+                }
+                });
 
-        table(class="table-auto w-full mt-4")
-          tbody
-            +tableRow()
-              +tableCell('# of Executions')
-              +tableCell(graph.summary.total)
-            +tableRow()
-              +tableCell('# Success')
-              +tableCell(graph.summary.success)
-            +tableRow()
-              +tableCell('# Failure')
-              +tableCell(graph.summary.failure)
-            +tableRow()
-              +tableCell('Avg Duration (s)')
-              +tableCell(graph.summary.avgDuration)
-            +tableRow()
-              +tableCell('Min Duration (s)')
-              +tableCell(graph.summary.minDuration)
-            +tableRow()
-              +tableCell('Max Duration (s)')
-              +tableCell(graph.summary.maxDuration)
+          table(class="table-auto w-full mt-4")
+            tbody
+              +tableRow()
+                +tableCell('# of Executions')
+                +tableCell(graph.summary.total)
+              +tableRow()
+                +tableCell('# Success')
+                +tableCell(graph.summary.success)
+              +tableRow()
+                +tableCell('# Failure')
+                +tableCell(graph.summary.failure)
+              +tableRow()
+                +tableCell('Avg Duration (s)')
+                +tableCell(graph.summary.avgDuration)
+              +tableRow()
+                +tableCell('Min Duration (s)')
+                +tableCell(graph.summary.minDuration)
+              +tableRow()
+                +tableCell('Max Duration (s)')
+                +tableCell(graph.summary.maxDuration)
+        else
+          p No task executions found with this filter criteria


### PR DESCRIPTION
This PR updates the task summary page to only show the task graph & stats section if the task actually has executions in the filter that is selected.

Closes #166 