### PR TITLE
♻️ Ensure config values are strings in API

### DIFF
--- a/api/admin/configDefaults.js
+++ b/api/admin/configDefaults.js
@@ -9,8 +9,14 @@
  * @param {*} db
  */
 async function handle(req, res, serverConf, cache, db) {
-  const defaults = await cache.fetchSystemDefaults();
-  res.send(defaults != null ? defaults : { defaults: {} });
+  const systemDefaults = await cache.fetchSystemDefaults();
+  let defaults = {};
+  if (systemDefaults != null) {
+    Object.keys(systemDefaults.defaults).forEach(function(key) {
+      defaults[key] = systemDefaults.defaults[key].toString();
+    });
+  }
+  res.send({ defaults: defaults });
 }
 
 module.exports.handle = handle;

--- a/api/admin/configOverrides.js
+++ b/api/admin/configOverrides.js
@@ -9,8 +9,14 @@
  * @param {*} db
  */
 async function handle(req, res, serverConf, cache, db) {
-  const overrides = await cache.fetchSystemOverrides();
-  res.send(overrides != null ? overrides : { overrides: {} });
+  const systemOverrides = await cache.fetchSystemOverrides();
+  let overrides = {};
+  if (systemOverrides != null) {
+    Object.keys(systemOverrides.overrides).forEach(function(key) {
+      overrides[key] = systemOverrides.overrides[key].toString();
+    });
+  }
+  res.send({ overrides: overrides });
 }
 
 module.exports.handle = handle;


### PR DESCRIPTION
This PR standardizes the config values in the REST API to ensure they are returned as strings.

closes #170 