### PR TITLE
✨ Can cancel tasks even marked as completed

### DIFF
--- a/views/monitor/buildTaskDetails.pug
+++ b/views/monitor/buildTaskDetails.pug
@@ -27,10 +27,7 @@ block content
                 +tableCell(task.node)
               +tableRow()
                 +tableCellButton('Requeue', '/monitor/requeueTask?taskID=' + task.task_id)
-                if task.conclusion == null
-                  +tableCellButton('Cancel', '/monitor/cancelTask?taskID=' + task.task_id)
-                else
-                  +tableCell('')
+                +tableCellButton('Cancel', '/monitor/cancelTask?taskID=' + task.task_id)
 
     +infoCard('Task Config')
         table(class="table-auto w-full")


### PR DESCRIPTION
This PR allows any task to be cancelled, even if it is marked as completed. This only applies to the monitor flow. This allows an admin to clear out a task in the case of a stampede task update failure.

closes #174 