### PR TITLE
🐛 Fixed width on task config example

### DIFF
--- a/views/admin/taskConfig.pug
+++ b/views/admin/taskConfig.pug
@@ -45,7 +45,7 @@ block content
                   +tableCell(config.value)
 
   div(class="flex flex-wrap m-4")
-    div(class="w-full md:w-1/2 xl:w-1/3 p-3")
+    div(class="w-full p-3")
       div(class="bg-white border-transparent rounded-lg shadow-lg")
         div(class="bg-gray-400 uppercase text-gray-800 border-b-2 border-gray-500 rounded-tl-lg rounded-tr-lg p-2")
           h5(class="font-bold uppercase text-gray-600") .stampede.yaml example


### PR DESCRIPTION
This PR makes the task config example wider on the page so it can fit larger text.

closes #178 