### PR TITLE
♻️ limit active tasks to tasks that are in progress

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -226,33 +226,14 @@ async function fetchRecentFailedTasks() {
 
 /**
  * activeTasks
- * @param {string} owner
- * @param {string} repository
  */
-async function activeTasks(hours, owner, repository) {
-  if (owner != null && repository != null) {
-    const query =
-      "SELECT * FROM stampede.tasks \
-      WHERE status = $1 AND \
-      owner = $2 AND \
-      repository = $3 \
-      ORDER BY started_at DESC";
-    return await pool.query(query, ["completed", owner, repository]);
-  } else if (owner != null) {
-    const query =
-      "SELECT * FROM stampede.tasks \
-      WHERE status != $1 AND \
-      owner = $2 \
-      ORDER BY started_at DESC";
-    return await pool.query(query, ["completed", owner]);
-  } else {
-    const query =
-      "SELECT * FROM stampede.builds, stampede.tasks \
-      WHERE tasks.status != $1 AND \
+async function activeTasks() {
+  const query =
+    "SELECT * FROM stampede.builds, stampede.tasks \
+      WHERE tasks.status = $1 AND \
       tasks.build_id = builds.build_id \
       ORDER BY tasks.started_at DESC";
-    return await pool.query(query, ["completed"]);
-  }
+  return await pool.query(query, ["in_progress"]);
 }
 
 /**


### PR DESCRIPTION
This PR updates the active task screen and API call to only return tasks that are in progress. Queued tasks will no longer be included in the list.

closes #195 